### PR TITLE
Installation owncloud-client via standard repo

### DIFF
--- a/final_installation/terminal_server/32_Owncloud.sh
+++ b/final_installation/terminal_server/32_Owncloud.sh
@@ -11,6 +11,7 @@ then
   sudo apt-get install --assume-yes owncloud-client owncloud-client-cmd owncloud-client-doc owncloud-client-l10n
 else
   # Owncloud installation for older Ubuntu releases
+  echo "Installation from opensuse repository"
   wget -q -O - http://download.opensuse.org/repositories/isv:ownCloud:desktop/Ubuntu_14.04/Release.key | sudo apt-key add -
 
   sudo sh -c "echo 'deb http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/Ubuntu_14.04/ /' > /etc/apt/sources.list.d/owncloud-client.list"

--- a/final_installation/terminal_server/32_Owncloud.sh
+++ b/final_installation/terminal_server/32_Owncloud.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
 
-# Owncloud installation
-wget -q -O - http://download.opensuse.org/repositories/isv:ownCloud:desktop/Ubuntu_14.04/Release.key | sudo apt-key add -
+# check if we have a Ubuntu 16.04
+UBUNTU_RELEASE=$(lsb_release -c | sed 's/^.*:[[:space:]]*//g')
+echo "Identified Ubuntu release $UBUNTU_RELEASE"
 
-sudo sh -c "echo 'deb http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/Ubuntu_14.04/ /' > /etc/apt/sources.list.d/owncloud-client.list"
-sudo apt-get update
-sudo apt-get --assume-yes install owncloud-client
+if [ "$UBUNTU_RELEASE" == "xenial" ]
+then
+  # it seems to be 16.04, we can install owncloud from the standard repository
+  echo "Installation from standard repository"
+  sudo apt-get install --assume-yes owncloud-client owncloud-client-cmd owncloud-client-doc owncloud-client-l10n
+else
+  # Owncloud installation for older Ubuntu releases
+  wget -q -O - http://download.opensuse.org/repositories/isv:ownCloud:desktop/Ubuntu_14.04/Release.key | sudo apt-key add -
+
+  sudo sh -c "echo 'deb http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/Ubuntu_14.04/ /' > /etc/apt/sources.list.d/owncloud-client.list"
+  sudo apt-get update
+  sudo apt-get --assume-yes install owncloud-client
+fi


### PR DESCRIPTION
The installation of owncloud-client is now performed via standard repository in case of 16.04

The old installation procedure is kept for Ubuntu releases not being 16.04.

Fixes #6 
