### PR TITLE
Remove guest login only for older Ubuntu releases

### DIFF
--- a/final_installation/terminal_server/80_remove_guest_login.sh
+++ b/final_installation/terminal_server/80_remove_guest_login.sh
@@ -1,3 +1,16 @@
 #!/bin/bash
 
-sudo su root -c "printf '[SeatDefaults]\nallow-guest=false\n' > /etc/lightdm/lightdm.conf.d/99-disallow-guest.conf"
+# check if we have a Ubuntu 16.04
+UBUNTU_RELEASE=$(lsb_release -c | sed 's/^.*:[[:space:]]*//g')
+echo "Identified Ubuntu release $UBUNTU_RELEASE"
+
+if [ "$UBUNTU_RELEASE" == "xenial" ]
+then
+  # it seems to be 16.04, we do not need to disable guest login
+  echo "Ubuntu 16.04 found, therefore no guest login needs to be disabled."
+else
+  # Before Ubuntu 16.04, we need to disable guest login
+  echo "Older release means we need to disable guest login"
+  sudo su root -c "printf '[SeatDefaults]\nallow-guest=false\n' > /etc/lightdm/lightdm.conf.d/99-disallow-guest.conf"
+fi
+


### PR DESCRIPTION
For Ubuntu 16.04 the disabling step for the guest login is not required any more.

For older releases the deactivation is still working
