### PR TITLE
munge configuration to log via syslog

### DIFF
--- a/final_installation/terminal_server/102_install_slurm-client.sh
+++ b/final_installation/terminal_server/102_install_slurm-client.sh
@@ -18,4 +18,32 @@ sudo bash -c 'base64 --decode > /etc/munge/munge.key'
 sudo scp cctbadmin@slurmmaster:/etc/slurm-llnl/slurm.conf /etc/slurm-llnl/
 sudo chown slurm.slurm /etc/slurm-llnl/slurm.conf
 
-sudo service munge restart
+SERVICE2CHECK="munge.service"
+
+systemctl cat "$SERVICE2CHECK" | grep "ExecStart.*--syslog|ExecStart.*--force" >/dev/null
+
+PRESENT_OR_NOT=$?
+
+if [ $PRESENT_OR_NOT -eq 1 ]
+then  
+	FOLDER=/etc/systemd/system/
+	OUTFILE="$FOLDER"/"$SERVICE2CHECK"
+	
+	if [ -e "$OUTFILE" ]
+	then
+		echo "Outputfile '$OUTFILE' exists. Please remove it."
+		exit 1
+	fi
+
+	echo "Creating Folder $FOLDER"
+  mkdir -p "$FOLDER"
+
+	systemctl cat "$SERVICE2CHECK" | sed '/ExecStart/{s/$/ --syslog/}' >"$OUTFILE"
+
+	systemctl daemon-reload
+	systemctl start "$SERVICE2CHECK"
+
+else 
+	echo "Already present"
+
+fi


### PR DESCRIPTION
This avoids the refuse of munge to start, due to wrong permissions for log folder.

Fixes #32